### PR TITLE
mkctr: use `DockerManifestList` instead of `OCIImageIndex`.

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func fetchAndBuild(bp *buildParams) error {
 	}
 
 	// Generate a new index with all the platform images.
-	idx := mutate.AppendManifests(mutate.IndexMediaType(empty.Index, types.OCIImageIndex), adds...)
+	idx := mutate.AppendManifests(mutate.IndexMediaType(empty.Index, types.DockerManifestList), adds...)
 	d, err := idx.Digest()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #3

Signed-off-by: Maisem Ali <maisem@tailscale.com>