### PR TITLE
Ensure that newly built image layers are of the same media type as the base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ mkctr \
   [--] [<cmd>...]
 ```
 
-`mkctr` auto discovers `GOOS`/`GOARCH` from the specified base image. If the base image supports multiple platforms, binaries are compiled for each platform as long as it's one of `linux/amd64`, `linux/386`, `linux/arm`, `linux/arm64`.
+`mkctr` auto discovers `GOOS`/`GOARCH` from the specified base image. If the base image supports multiple platforms, binaries are compiled for each platform as long as it's one of `linux/amd64`, `linux/386`, `linux/arm`, `linux/arm64`. Multi-arch base image must be either an [OCI image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md) or [Docker manifest list](https://github.com/openshift/docker-distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list).
+`mkctr` produces image of the same media type as the base image and uses the media type of the base image, or of the individual image references in case of a multi-arch image, to determine the media type of the layer it builds.
+
 
 ## Maturity
 This is under active development. While Tailscale uses it, backwards compatability is not guaranteed, and some functionality is missing.

--- a/mkctr.go
+++ b/mkctr.go
@@ -373,7 +373,21 @@ func createImageForBase(bp *buildParams, logf logf, base v1.Image, platform v1.P
 		logf("output %v -> %v", gp, n)
 		files[n] = dst
 	}
-	layer, err := layerFromFiles(logf, files)
+	// Determine media type of the base image.
+	var layerMediaType types.MediaType
+	mt, err := base.MediaType()
+	if err != nil {
+		return nil, fmt.Errorf("error determining base image media type: %w", err)
+	}
+	switch mt {
+	case types.OCIManifestSchema1:
+		layerMediaType = types.OCILayer
+	case types.DockerManifestSchema2:
+		layerMediaType = types.DockerLayer
+	default:
+		return nil, fmt.Errorf("unknown base image media type %v, accepted types are OCI image manifest v1 (%s) and Docker image manifest v2 (%s)", mt, types.OCIManifestSchema1, types.DockerManifestSchema2)
+	}
+	layer, err := layerFromFiles(logf, files, layerMediaType)
 	if err != nil {
 		return nil, err
 	}
@@ -416,7 +430,7 @@ func compileGoBinary(what, where string, env []string, ldflags, gotags string, v
 	return out, nil
 }
 
-func layerFromFiles(logf logf, files map[string]string) (v1.Layer, error) {
+func layerFromFiles(logf logf, files map[string]string, layerMediaType types.MediaType) (v1.Layer, error) {
 	buf := bytes.NewBuffer(nil)
 	tw := tar.NewWriter(buf)
 	defer tw.Close()
@@ -458,7 +472,18 @@ func layerFromFiles(logf logf, files map[string]string) (v1.Layer, error) {
 		return nil, err
 	}
 
-	return tarball.LayerFromReader(buf, tarball.WithCompressedCaching)
+	binaryLayerBytes := buf.Bytes()
+	// An alternative to using tarball.LayerFromOpener would be to use
+	// stream.NewLayer
+	// https://pkg.go.dev/github.com/google/go-containerregistry@v0.17.0/pkg/v1/stream#NewLayer.
+	// This would, however, require us to restructure the code to write each
+	// layer to the upstream repository immediately after producing it. At
+	// this point we (irbekrm) are not sure if there would be any benefits
+	// to switching to stream.NewLayer.
+	// https://github.com/google/go-containerregistry/tree/main/pkg/v1/stream#caveats
+	return tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewBuffer(binaryLayerBytes)), nil
+	}, tarball.WithCompressedCaching, tarball.WithMediaType(layerMediaType))
 }
 
 func tarFile(tw *tar.Writer, src, dst string) error {


### PR DESCRIPTION
Currently, we do not specify the media type for the image layer produced by mkctr and it ends up being defaulted to `application/vnd.docker.image.rootfs.diff.tar.gzip` (I haven't checked what in containerregistry code does the defaulting).
The `tailscale/alpine` base image that we use to build `tailscale/tailscale` and `tailscale/k8s-operator` images contains `application/vnd.oci.image.layer.v1.tar+gzip` layers so we end up producing an image with multiple layer types, see below
<details>
<code>
skopeo inspect docker://tailscale/tailscale:v1.56.1
{
    "Name": "docker.io/tailscale/tailscale",
    "Digest": "sha256:ac0c192f6cba52877e4d9c2fe8943f16c0ab44927605a21416852590e3ccb71e",
...
 "Created": "2023-12-15T19:55:32.316302324Z",
    "DockerVersion": "",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:c926b61bad3b94ae7351bafd0c184c159ebf0643b085f7ef1d47ecdc7316833c",
        "sha256:178ff4e539eb7f069b711c441705284031a3fe08eeabd504f91cf2c73d224800",
        "sha256:aaa9ae6eb9ac19afc4bf1af3494b98d5aefbf544a0bb90ebd6693c621d00f1a8"
    ],
    "LayersData": [
        {
            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
            "Digest": "sha256:c926b61bad3b94ae7351bafd0c184c159ebf0643b085f7ef1d47ecdc7316833c",
            "Size": 3402422,
            "Annotations": null
        },
        {
            "MIMEType": "application/vnd.oci.image.layer.v1.tar+gzip",
            "Digest": "sha256:178ff4e539eb7f069b711c441705284031a3fe08eeabd504f91cf2c73d224800",
            "Size": 2544698,
            "Annotations": null
        },
        {
            "MIMEType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
            "Digest": "sha256:aaa9ae6eb9ac19afc4bf1af3494b98d5aefbf544a0bb90ebd6693c621d00f1a8",
            "Size": 38812769,
            "Annotations": null
        }
    ],
    "Env": null
}
</code>
</details>


Tools like podman and buildah reject images with mixed layer types, see containers/buildah#3668

This PR:
- detects base image media type and builds the new layer of the same type
- switches from the deprecated LayerFromReader func to LayerFromOpener.

I have tested that `tailscale/tailscale` and `tailscale/k8s-operator` images built from this PR are functioning and also that they can be used as a base when building a new image with `podman build`.

Updates tailscale/mkctr#10
Updates tailscale/tailscale#9902