### PR TITLE
Build an image of the same type as the base image

### DIFF
--- a/mkctr.go
+++ b/mkctr.go
@@ -300,8 +300,10 @@ func fetchAndBuild(bp *buildParams) error {
 		}
 		return nil
 	}
-	// Generate a new index with all the platform images.
-	idx := mutate.AppendManifests(mutate.IndexMediaType(empty.Index, types.DockerManifestList), adds...)
+	// Generate a new 'fat manifest' with all the platform images. If we are
+	// at this point the base was either a Dokcer manifest list or an OCI
+	// image index- make sure the new manifest of that type.
+	idx := mutate.AppendManifests(mutate.IndexMediaType(empty.Index, baseDesc.MediaType), adds...)
 	d, err := idx.Digest()
 	if err != nil {
 		return err


### PR DESCRIPTION
Multi-arch images were previously built of type docker manifest list even if they were OCI image index because DockerHub was displaying OCI image indexes incorrectly, see #3 

This now seems to be fixed (I haven't checked if the fix was in DockerHub or containerregistry lib), see `tailscale/alpine-base` which is an OCI image index https://hub.docker.com/r/tailscale/alpine-base/tags

```
gcrane manifest tailscale/alpine-base:3.18
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:c9070fde2e438f14a602d8b34c2f7deed76da52e58f48f5bcca11cbf50054a67",
      "size": 672,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
....
```

Updates#cleanup