### PR TITLE
go.mod: relax the Go version constraint a bit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/tailscale/mkctr
 
 // Use point versions of Go, see https://github.com/tailscale/tailscale/pull/13485
-go 1.23.3
+go 1.23.1
 
 require github.com/google/go-containerregistry v0.20.2
 


### PR DESCRIPTION
Or else we're requiring that all importers are on Go version >= 1.23.3.

I could alternatively bump all the tailscale/tailscale things to 1.23.3, but this is quite a bit more work + looking at history bumping for Go patch releases does not seem to be a thing and looking at the Go 1.23's patch release notes there is not anything that we care about https://go.dev/doc/devel/release#go1.23.0

Updates#cleanup