### PR TITLE
mkctr.go: fix GOARM env var

### DIFF
--- a/mkctr.go
+++ b/mkctr.go
@@ -417,7 +417,7 @@ func createImageForBase(bp *buildParams, logf logf, base v1.Image, platform v1.P
 		if err != nil {
 			return nil, err
 		}
-		env = append(env, v)
+		env = append(env, "GOARM="+v)
 	}
 
 	files := map[string]string{}


### PR DESCRIPTION
Fixes a bug where arm variant was previously exported as a keyless env var `7`, now it's `GOARM=7`.

I have verified that this fixes tailscale/tailscale#15159

Updates tailscale/tailscale#15159